### PR TITLE
Fix problem with port when ssh-keyscan

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -72,7 +72,7 @@ runs:
       if: ${{ inputs.remote_ssh_known_hosts }} = ''
       run: |
         echo "::warning::You may want to set REMOTE_SSH_KNOWN_HOSTS as a GitHub Actions secret to improve security."
-        ssh-keyscan -H ${{ inputs.remote_ssh_server_hostname }} -p ${{inputs.remote_ssh_port}} >> ~/.ssh/known_hosts
+        ssh-keyscan -p ${{inputs.remote_ssh_port}} -H ${{ inputs.remote_ssh_server_hostname }} >> ~/.ssh/known_hosts
         chmod 644 ~/.ssh/known_hosts
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -72,7 +72,7 @@ runs:
       if: ${{ inputs.remote_ssh_known_hosts }} = ''
       run: |
         echo "::warning::You may want to set REMOTE_SSH_KNOWN_HOSTS as a GitHub Actions secret to improve security."
-        ssh-keyscan -H ${{ inputs.remote_ssh_server_hostname }} >> ~/.ssh/known_hosts
+        ssh-keyscan -H ${{ inputs.remote_ssh_server_hostname }} -p ${{inputs.remote_ssh_port}} >> ~/.ssh/known_hosts
         chmod 644 ~/.ssh/known_hosts
       shell: bash
 


### PR DESCRIPTION
When using a port other than the default port for ssh connection, the action failed because the default port for ssh-keyscan (22) was used.
![image](https://github.com/serversideup/github-action-docker-swarm-deploy/assets/36962784/10166f1b-e348-4d45-b894-21e378924b5d)

All we had to do was add the -p parameter and use the already ready variable with the port
`ssh-keyscan -p ${{inputs.remote_ssh_port}} -H ${{ inputs.remote_ssh_server_hostname }} >> ~/.ssh/known_hosts`

![image](https://github.com/serversideup/github-action-docker-swarm-deploy/assets/36962784/8bb18b84-f061-40d0-85dc-58d2fe6c421e)
