### PR TITLE
fix: bump checkout & login-action to node24 majors (clears Node 20 deprecation, #9)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -60,7 +60,7 @@ runs:
   steps:
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set MD5 checksum (if provided)
       if: ${{ inputs.md5_file_path }}
@@ -183,7 +183,7 @@ runs:
       shell: bash
 
     - name: Login to registry. (${{ inputs.registry }})
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         username: ${{ inputs.registry-username }}
         password: ${{ inputs.registry-password || inputs.registry-token }}


### PR DESCRIPTION
Closes #9.

## Problem

GitHub is retiring the Node.js 20 actions runtime (forced to Node 24 on 2026-06-02, Node 20 removed 2026-09-16). This composite action pins two actions that run on `node20`, so every consumer sees the deprecation annotation:

| Step | Was | Runtime |
|---|---|---|
| `actions/checkout` | `@v4` | node20 |
| `docker/login-action` | `@v3` | node20 |

## Change

Bumped to the current majors, each of which declares `using: node24` in its `action.yml`:

- `actions/checkout` `@v4` → `@v5`
- `docker/login-action` `@v3` → `@v4`

`checkout` is invoked bare (no `with:`) and `login-action` only with `username`/`password`/`registry` — all unchanged across these majors, so this is **non-breaking for consumers**.

## Validation

A full swarm deploy can't be exercised without SSH/Swarm infra, so I isolated exactly the two actions this PR changes and ran them on a real GitHub-hosted runner ([run](https://github.com/magicyoda/github-action-docker-swarm-deploy/actions/runs/26055887139)):

- Both `actions/checkout@v5` and `docker/login-action@v4` steps completed **success**.
- **Zero** annotations on the run (verified via the check-runs annotations API, authoritative — not log scraping).
- Baseline sanity: under identical runner conditions `actions/checkout@v4` *does* still emit the Node-20 deprecation, so the clean result is meaningful rather than a measurement gap.
- Static confirmation: `actions/checkout@v5` and `docker/login-action@v4` both declare `using: node24`.

The validation workflow is intentionally **not** part of this PR (kept on a separate branch).

Companion to serversideup/github-action-docker-build#2 (same fix for the build action).

---

🤖 Authored by [Claude Code](https://claude.com/claude-code) (Opus 4.7), reviewed and run by @magicyoda.